### PR TITLE
Add reliable test setup script and compose service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Если используешь psycopg[binary], можно обойтись и без build-essential,
 # но оставим универсально.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      build-essential curl \
+      build-essential curl postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # 4) Рабочая директория

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,14 @@ services:
       sh -c "alembic upgrade head &&
              uvicorn app.main:app --host 0.0.0.0 --port 8000"
 
+  app-test:
+    build: .
+    container_name: qa_app_test
+    env_file: [.env]
+    depends_on:
+      db:
+        condition: service_healthy
+    entrypoint: ["bash", "tests/run-tests.sh"]
+
 volumes:
   postgres_data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,35 +1,29 @@
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from alembic.config import Config
-from alembic import command
 
 from app.main import app
 from app.api.deps import get_db
 from app.core.config import settings
 
 TEST_DATABASE_URL = settings.TEST_DATABASE_URL
-
-@pytest.fixture(scope="session", autouse=True)
-def apply_migrations():
-    config = Config("alembic.ini")
-    config.set_main_option("sqlalchemy.url", settings.TEST_DATABASE_URL)
-    command.upgrade(config, "head")
-    yield
-
 engine = create_engine(TEST_DATABASE_URL)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+
 @pytest.fixture()
-def db_session(apply_migrations):
+def db_session():
     connection = engine.connect()
     transaction = connection.begin()
     session = TestingSessionLocal(bind=connection)
-    yield session
-    session.close()
-    transaction.rollback()
-    connection.close()
+    try:
+        yield session
+    finally:
+        session.close()
+        transaction.rollback()
+        connection.close()
+
 
 @pytest.fixture()
 def client(db_session):
@@ -40,5 +34,7 @@ def client(db_session):
             db_session.close()
 
     app.dependency_overrides[get_db] = override_get_db
-    yield TestClient(app)
-    del app.dependency_overrides[get_db]
+    try:
+        yield TestClient(app)
+    finally:
+        del app.dependency_overrides[get_db]

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Wait for PostgreSQL to be ready
-until pg_isready -h db -p 5432 -U "$POSTGRES_USER" >/dev/null 2>&1; do
+# Wait for PostgreSQL to be ready with timeout
+for i in {1..60}; do
+  if pg_isready -h db -p 5432 -U "$POSTGRES_USER" >/dev/null 2>&1; then
+    break
+  fi
   echo "Waiting for PostgreSQL..."
   sleep 1
+  if [ "$i" -eq 60 ]; then
+    echo "PostgreSQL not ready after 60 seconds"
+    exit 1
+  fi
 done
 
 # Prepare clean test database

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wait for PostgreSQL to be ready
+until pg_isready -h db -p 5432 -U "$POSTGRES_USER" >/dev/null 2>&1; do
+  echo "Waiting for PostgreSQL..."
+  sleep 1
+done
+
+# Prepare clean test database
+export PGPASSWORD="$POSTGRES_PASSWORD"
+psql -h db -U "$POSTGRES_USER" -d postgres -c "DROP DATABASE IF EXISTS test_app;"
+psql -h db -U "$POSTGRES_USER" -d postgres -c "CREATE DATABASE test_app;"
+
+# Run migrations
+alembic -x sqlalchemy.url="$TEST_DATABASE_URL" upgrade head
+
+# Execute tests
+pytest "$@"


### PR DESCRIPTION
## Summary
- Add `tests/run-tests.sh` wrapper to wait for Postgres, recreate the test database, run migrations and execute pytest
- Introduce `app-test` service in `docker-compose.yml` to run the new script
- Simplify test fixtures now that the database is prepared externally

## Testing
- `docker compose run --rm app-test` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b06b5e119c832585ef7daf639e4cd0