### PR TITLE
Add postgresql client to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 # Если используешь psycopg[binary], можно обойтись и без build-essential,
 # но оставим универсально.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      build-essential curl \
+      build-essential curl postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # 4) Рабочая директория


### PR DESCRIPTION
## Summary
- install postgresql-client in Docker image to support PostgreSQL tools

## Testing
- `docker compose build app app-test` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68b075a4eb448325b2b6caf26f977d40