### PR TITLE
Add timeout to PostgreSQL readiness check

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Simple readiness wait for PostgreSQL with timeout
+HOST="${POSTGRES_HOST:-localhost}"
+PORT="${POSTGRES_PORT:-5432}"
+SLEEP_INTERVAL=1
+MAX_WAIT="${POSTGRES_READY_TIMEOUT:-30}"
+
+elapsed=0
+while ! nc -z "$HOST" "$PORT" >/dev/null 2>&1; do
+  if [ "$elapsed" -ge "$MAX_WAIT" ]; then
+    echo "ERROR: PostgreSQL is still unreachable at ${HOST}:${PORT} after ${MAX_WAIT}s." >&2
+    exit 1
+  fi
+  echo "Waiting for PostgreSQL at ${HOST}:${PORT}... (${elapsed}s elapsed)"
+  sleep "$SLEEP_INTERVAL"
+  elapsed=$((elapsed + SLEEP_INTERVAL))
+done
+
+echo "PostgreSQL is up after ${elapsed}s. Running tests..."
+pytest "$@"


### PR DESCRIPTION
## Summary
- add `tests/run-tests.sh` with PostgreSQL readiness wait including timeout and descriptive error

## Testing
- `POSTGRES_READY_TIMEOUT=3 bash tests/run-tests.sh` (fails: PostgreSQL is unreachable)
- `DATABASE_URL=sqlite:///./test.db TEST_DATABASE_URL=sqlite:///./test.db pytest` (fails: tests/test_questions.py::test_delete_question_cascade)`

------
https://chatgpt.com/codex/tasks/task_e_68b075a820c48325bceaceb3885404a6